### PR TITLE
estimateEmbeddingDimension returns NA instead of 0 if no dimension found in range

### DIFF
--- a/R/getMinimumEmbeddingDimension.R
+++ b/R/getMinimumEmbeddingDimension.R
@@ -106,8 +106,10 @@ estimateEmbeddingDim = function(
   tsBeg = time.series.len / 2 - number.points / 2 + 1
   tsEnd = time.series.len / 2 + number.points / 2
   data = time.series[tsBeg:tsEnd]
-  #if no d verifies E1(d) >= threshold,  then we shall return 0
-  embedding.dim = 0 
+
+  # initialize embedding dimension
+  embedding.dim = 0
+
   # First iteration: get E1(1) and E2(1)
   E.parameters = getCaoParameters(data,  1,  time.lag)
   E.parameters.next.dim = getCaoParameters(data,  2,  time.lag)
@@ -160,7 +162,12 @@ estimateEmbeddingDim = function(
            legend = c("E1(d)", "E2(d)", "limits for E1(d)")
     )
   }
-  embedding.dim 
+
+  # if no embedding dimension has been identified, return NA instead
+  if (embedding.dim==0){ embedding.dim = NA}
+
+  # return embedding dimension
+  return(embedding.dim)
 }
 
 

--- a/R/getMinimumEmbeddingDimension.R
+++ b/R/getMinimumEmbeddingDimension.R
@@ -17,6 +17,9 @@
 #'  search (For more information on the ANN library please visit 
 #'  \url{http://www.cs.umd.edu/~mount/ANN/}). The R wrapper is a modified 
 #'  version of the RANN package code by Samuel E. Kemp and Gregory Jefferis.
+#'
+#' If no suitable embedding dimension can be found within the provided range,
+#' the function will return NA.
 #' @note
 #' In the current version of the package, the automatic detection of stochastic 
 #' signals has not been implemented yet.


### PR DESCRIPTION
Following up on the discussion in Issue #4, this PR implements a change to `estimateEmbeddingDimension` such that it will return `NA` instead of `0` if no suitable embedding dimension is found within the user-specified range. The PR also includes an update to the documentation to clarify the output.

Thanks!